### PR TITLE
feat(db): add group management migrations (009–012)

### DIFF
--- a/backend/migrations/000009_create_groups.down.sql
+++ b/backend/migrations/000009_create_groups.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS groups;

--- a/backend/migrations/000009_create_groups.up.sql
+++ b/backend/migrations/000009_create_groups.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE groups (
+    id          SERIAL PRIMARY KEY,
+    name        VARCHAR(100) NOT NULL,
+    description TEXT,
+    owner_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    meeting_id  INTEGER REFERENCES meetings(id) ON DELETE SET NULL,
+    created_at  TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at  TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+CREATE INDEX idx_groups_owner_id   ON groups(owner_id);
+CREATE INDEX idx_groups_meeting_id ON groups(meeting_id);

--- a/backend/migrations/000010_create_group_members.down.sql
+++ b/backend/migrations/000010_create_group_members.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS group_members;

--- a/backend/migrations/000010_create_group_members.up.sql
+++ b/backend/migrations/000010_create_group_members.up.sql
@@ -1,0 +1,10 @@
+CREATE TABLE group_members (
+    id        SERIAL PRIMARY KEY,
+    group_id  INTEGER NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    user_id   INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role      VARCHAR(20) NOT NULL DEFAULT 'member',
+    joined_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE(group_id, user_id)
+);
+CREATE INDEX idx_group_members_group_id ON group_members(group_id);
+CREATE INDEX idx_group_members_user_id  ON group_members(user_id);

--- a/backend/migrations/000011_create_group_invitations.down.sql
+++ b/backend/migrations/000011_create_group_invitations.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS group_invitations;

--- a/backend/migrations/000011_create_group_invitations.up.sql
+++ b/backend/migrations/000011_create_group_invitations.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE group_invitations (
+    id          SERIAL PRIMARY KEY,
+    group_id    INTEGER NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
+    invited_by  INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    email       VARCHAR(255) NOT NULL,
+    token       VARCHAR(64) UNIQUE NOT NULL,
+    status      VARCHAR(20) NOT NULL DEFAULT 'pending',
+    expires_at  TIMESTAMP WITH TIME ZONE NOT NULL,
+    accepted_at TIMESTAMP WITH TIME ZONE,
+    created_at  TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+CREATE INDEX idx_group_invitations_group_id ON group_invitations(group_id);
+CREATE INDEX idx_group_invitations_email    ON group_invitations(email);
+CREATE INDEX idx_group_invitations_token    ON group_invitations(token);

--- a/backend/migrations/000012_add_group_id_to_summarizer_sessions.down.sql
+++ b/backend/migrations/000012_add_group_id_to_summarizer_sessions.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_summarizer_sessions_group_id;
+ALTER TABLE summarizer_sessions DROP COLUMN IF EXISTS group_id;

--- a/backend/migrations/000012_add_group_id_to_summarizer_sessions.up.sql
+++ b/backend/migrations/000012_add_group_id_to_summarizer_sessions.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE summarizer_sessions
+    ADD COLUMN group_id INTEGER REFERENCES groups(id) ON DELETE SET NULL;
+CREATE INDEX idx_summarizer_sessions_group_id ON summarizer_sessions(group_id);


### PR DESCRIPTION
- 009: create `groups` table with owner_id and optional meeting_id FK
- 010: create `group_members` table with unique (group_id, user_id) constraint and role support
- 011: create `group_invitations` table with token-based invite flow and expiry
- 012: add nullable `group_id` FK to `summarizer_sessions` for group-scoped summaries

Closes #22, #23, #24, #25