### PR TITLE
Add enableListenerMode functionality to device lifecycle and error handling

### DIFF
--- a/frontend/src/hooks/useLobbyDevices/index.ts
+++ b/frontend/src/hooks/useLobbyDevices/index.ts
@@ -89,6 +89,7 @@ export function useLobbyDevices(meetingReady: boolean): LobbyDeviceState {
     handleDismissPrompt: deviceLifecycle.handleDismissPrompt,
     clearError: mediaStream.clearError,
     clearDeviceError: mediaStream.clearDeviceError,
+    enableListenerMode: deviceLifecycle.enableListenerMode,
     retryDeviceAccess: setupDevicesAndEnumerate,
     cleanup: useCallback(() => {
       mediaStream.stopStream();

--- a/frontend/src/hooks/useLobbyDevices/types.ts
+++ b/frontend/src/hooks/useLobbyDevices/types.ts
@@ -25,6 +25,7 @@ export interface LobbyDeviceState {
   handleDismissPrompt: () => void;
   clearError: () => void;
   clearDeviceError: () => void;
+  enableListenerMode: () => void;
   retryDeviceAccess: () => void;
   cleanup: () => void;
 }

--- a/frontend/src/hooks/useLobbyDevices/useDeviceLifecycle.ts
+++ b/frontend/src/hooks/useLobbyDevices/useDeviceLifecycle.ts
@@ -15,6 +15,7 @@ export interface DeviceLifecycleReturn {
   listenerMode: boolean;
   handleAllowPermissions: () => void;
   handleDismissPrompt: () => void;
+  enableListenerMode: () => void;
 }
 
 /**
@@ -70,10 +71,16 @@ export function useDeviceLifecycle({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [meetingReady]);
 
+  const enableListenerMode = () => {
+    setListenerMode(true);
+    enumerateDevices().catch(() => {});
+  };
+
   return {
     showPermissionPrompt,
     listenerMode,
     handleAllowPermissions,
     handleDismissPrompt,
+    enableListenerMode,
   };
 }

--- a/frontend/src/pages/MeetingLobby/ErrorDisplay.tsx
+++ b/frontend/src/pages/MeetingLobby/ErrorDisplay.tsx
@@ -6,6 +6,7 @@ interface ErrorDisplayProps {
   onClearDeviceError: () => void;
   onRetryDeviceAccess: () => void;
   onClearError: () => void;
+  onEnableListenerMode: () => void;
 }
 
 export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
@@ -14,6 +15,7 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
   onClearDeviceError,
   onRetryDeviceAccess,
   onClearError,
+  onEnableListenerMode,
 }) => {
   if (deviceError) {
     return (
@@ -27,7 +29,10 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
             // dialog appears on top of the modal, so the user keeps context.
             onRetryDeviceAccess();
           }}
-          onDismiss={onClearDeviceError}
+          onDismiss={() => {
+            onClearDeviceError();
+            onEnableListenerMode();
+          }}
         />
       </div>
     );

--- a/frontend/src/pages/MeetingLobby/index.tsx
+++ b/frontend/src/pages/MeetingLobby/index.tsx
@@ -69,6 +69,7 @@ export const MeetingLobby: React.FC<MeetingLobbyProps> = ({
         deviceError={devices.deviceError}
         error={displayError}
         onClearDeviceError={devices.clearDeviceError}
+        onEnableListenerMode={devices.enableListenerMode}
         onRetryDeviceAccess={async () => {
           // Browsers require getUserMedia to be called synchronously within the
           // user gesture (click). Calling it here directly — before any async


### PR DESCRIPTION
Resolves #62

This pull request introduces a new "listener mode" feature to the lobby device management flow, allowing users to switch to a mode where device enumeration occurs without requiring full device access. The changes add support for enabling listener mode in the device lifecycle, propagate this capability through the relevant hooks and UI components, and update error handling logic to trigger listener mode when dismissing device errors.

Enhancements to device lifecycle and lobby flow:

* Added `enableListenerMode` method to the `DeviceLifecycleReturn` interface and implemented its logic in `useDeviceLifecycle`, which sets listener mode and enumerates devices. [[1]](diffhunk://#diff-ec95fd8d2f01be1808ed35b59c93f45ccb82e3221018b03d5979b1b381aa420eR18) [[2]](diffhunk://#diff-ec95fd8d2f01be1808ed35b59c93f45ccb82e3221018b03d5979b1b381aa420eR74-R84)
* Propagated `enableListenerMode` through the `LobbyDeviceState` interface and `useLobbyDevices` hook, making it available for UI components. [[1]](diffhunk://#diff-857d07c6f18d25f4211db6e85d1b2d93534709b9fedb2517673a80f96062c240R28) [[2]](diffhunk://#diff-82de92c8dc78500c3d3e8cc7792c63c8f99d2378400d3c7e0002fff0e1ba686aR92)

UI and error handling improvements:

* Updated `ErrorDisplayProps` and `ErrorDisplay` component to accept and use `onEnableListenerMode`, ensuring listener mode is enabled when dismissing device errors. [[1]](diffhunk://#diff-838995d61ecb6d24ffdaef6a428367c9e139371d0e97ca073dfd5f047287c960R9) [[2]](diffhunk://#diff-838995d61ecb6d24ffdaef6a428367c9e139371d0e97ca073dfd5f047287c960R18) [[3]](diffhunk://#diff-838995d61ecb6d24ffdaef6a428367c9e139371d0e97ca073dfd5f047287c960L30-R35)
* Passed `onEnableListenerMode` from `MeetingLobby` to `ErrorDisplay`, connecting the new listener mode logic to the main lobby UI.