### PR TITLE
Refactor/share screen

### DIFF
--- a/frontend/src/components/meeting/CustomParticipantTile/index.tsx
+++ b/frontend/src/components/meeting/CustomParticipantTile/index.tsx
@@ -5,24 +5,37 @@ import {
   useIsSpeaking,
 } from "@livekit/components-react";
 import { Track } from "livekit-client";
+import { Pin } from "lucide-react";
 import { useParticipantData } from "./useParticipantData";
 import { AvatarDisplay } from "./AvatarDisplay";
 import { ParticipantInfo } from "./ParticipantInfo";
+import { usePinContext } from "../LiveKitMeetingRoom/PinContext";
 
 export const CustomParticipantTile: React.FC = () => {
   const trackRef = useEnsureTrackRef();
   const { participant, avatarUrl } = useParticipantData();
   const isSpeaking = useIsSpeaking(participant);
+  const { pinnedIdentity, setPinnedIdentity } = usePinContext();
 
   const isCameraTrack = trackRef?.source === Track.Source.Camera;
+  const isScreenShare = trackRef?.source === Track.Source.ScreenShare;
   const hasVideo =
     isCameraTrack &&
     trackRef?.publication?.isSubscribed &&
     !trackRef?.publication?.isMuted;
   const showAvatar = isCameraTrack && !hasVideo;
 
+  const isPinned = participant?.identity === pinnedIdentity;
+
+  const handlePinToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!participant) return;
+    setPinnedIdentity(isPinned ? null : participant.identity);
+  };
+
   return (
     <div
+      className="group"
       style={{
         position: "relative",
         width: "100%",
@@ -37,6 +50,20 @@ export const CustomParticipantTile: React.FC = () => {
       }}
     >
       <ParticipantTile />
+      {/* Pin button — visible on hover, always visible when pinned, hidden for screen share */}
+      {participant && !isScreenShare && (
+        <button
+          onClick={handlePinToggle}
+          title={isPinned ? "Unpin" : "Pin"}
+          className={`absolute top-2 left-2 z-20 flex items-center justify-center w-8 h-8 rounded-lg transition-opacity cursor-pointer backdrop-blur-sm border ${
+            isPinned
+              ? "opacity-100 bg-blue-500/80 border-blue-400/60 text-white"
+              : "opacity-0 group-hover:opacity-100 bg-black/60 hover:bg-black/80 border-white/20 text-white"
+          }`}
+        >
+          <Pin className={`w-4 h-4 ${isPinned ? "fill-current" : ""}`} />
+        </button>
+      )}
       {showAvatar && participant && (
         <div
           style={{

--- a/frontend/src/components/meeting/CustomParticipantTile/index.tsx
+++ b/frontend/src/components/meeting/CustomParticipantTile/index.tsx
@@ -50,7 +50,7 @@ export const CustomParticipantTile: React.FC = () => {
       }}
     >
       <ParticipantTile />
-      {/* Pin button — visible on hover, always visible when pinned, hidden for screen share */}
+      {/* Pin button — visible on hover, always visible (blue) when pinned, hidden for screen share */}
       {participant && !isScreenShare && (
         <button
           onClick={handlePinToggle}

--- a/frontend/src/components/meeting/CustomParticipantTile/useParticipantData.ts
+++ b/frontend/src/components/meeting/CustomParticipantTile/useParticipantData.ts
@@ -1,8 +1,9 @@
 import { useMemo } from "react";
-import { useEnsureParticipant } from "@livekit/components-react";
+import { useEnsureTrackRef } from "@livekit/components-react";
 
 export const useParticipantData = () => {
-  const participant = useEnsureParticipant();
+  const trackRef = useEnsureTrackRef();
+  const participant = trackRef?.participant ?? null;
 
   const metadata = useMemo(() => {
     try {

--- a/frontend/src/components/meeting/LiveKitMeetingRoom/PinContext.tsx
+++ b/frontend/src/components/meeting/LiveKitMeetingRoom/PinContext.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from "react";
+
+interface PinContextValue {
+  pinnedIdentity: string | null;
+  setPinnedIdentity: (identity: string | null) => void;
+}
+
+export const PinContext = createContext<PinContextValue>({
+  pinnedIdentity: null,
+  setPinnedIdentity: () => {},
+});
+
+export const usePinContext = () => useContext(PinContext);

--- a/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
+++ b/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
@@ -4,10 +4,13 @@ import {
   FocusLayout,
   FocusLayoutContainer,
   CarouselLayout,
+  TrackRefContext,
 } from "@livekit/components-react";
 import { Track } from "livekit-client";
 import type { TrackReferenceOrPlaceholder } from "@livekit/components-react";
+import { Pin } from "lucide-react";
 import { CustomParticipantTile } from "../CustomParticipantTile";
+import { PinContext } from "./PinContext";
 
 interface VideoLayoutProps {
   tracks: TrackReferenceOrPlaceholder[];
@@ -19,6 +22,18 @@ export const VideoLayout: React.FC<VideoLayoutProps> = ({
   hasScreenShare,
 }) => {
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [pinnedIdentity, setPinnedIdentity] = useState<string | null>(null);
+
+  const pinContextValue = { pinnedIdentity, setPinnedIdentity };
+
+  // Find the pinned participant's camera track (fallback to any track)
+  const pinnedTrack = pinnedIdentity
+    ? (tracks.find(
+        (t) =>
+          t.participant?.identity === pinnedIdentity &&
+          t.source === Track.Source.Camera,
+      ) ?? tracks.find((t) => t.participant?.identity === pinnedIdentity))
+    : null;
 
   if (hasScreenShare) {
     const screenTrack = tracks.find(
@@ -27,65 +42,100 @@ export const VideoLayout: React.FC<VideoLayoutProps> = ({
 
     if (isFullscreen) {
       return (
-        <div className="group relative w-full h-full bg-black">
-          <FocusLayout trackRef={screenTrack} />
-          <button
-            onClick={() => setIsFullscreen(false)}
-            title="Exit fullscreen"
-            className="absolute top-3 right-3 z-50 flex items-center justify-center w-9 h-9 rounded-lg bg-black/60 hover:bg-black/80 text-white transition-opacity opacity-0 group-hover:opacity-100 cursor-pointer backdrop-blur-sm border border-white/20"
-          >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
+        <PinContext.Provider value={pinContextValue}>
+          <div className="group relative w-full h-full bg-black">
+            <FocusLayout trackRef={screenTrack} />
+            <button
+              onClick={() => setIsFullscreen(false)}
+              title="Exit fullscreen"
+              className="absolute top-3 right-3 z-50 flex items-center justify-center w-9 h-9 rounded-lg bg-black/60 hover:bg-black/80 text-white transition-opacity opacity-0 group-hover:opacity-100 cursor-pointer backdrop-blur-sm border border-white/20"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9 9L4 4m0 0l5 0M4 4l0 5M15 9l5-5m0 0l-5 0m5 0l0 5M9 15l-5 5m0 0l5 0m-5 0l0-5M15 15l5 5m0 0l-5 0m5 0l0-5"
-              />
-            </svg>
-          </button>
-        </div>
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 9L4 4m0 0l5 0M4 4l0 5M15 9l5-5m0 0l-5 0m5 0l0 5M9 15l-5 5m0 0l5 0m-5 0l0-5M15 15l5 5m0 0l-5 0m5 0l0-5"
+                />
+              </svg>
+            </button>
+          </div>
+        </PinContext.Provider>
       );
     }
 
     return (
-      <FocusLayoutContainer>
-        <CarouselLayout tracks={tracks}>
-          <CustomParticipantTile />
-        </CarouselLayout>
-        <div className="group relative flex-1 min-w-0 min-h-0">
-          <FocusLayout trackRef={screenTrack} />
-          <button
-            onClick={() => setIsFullscreen(true)}
-            title="Fullscreen"
-            className="absolute top-3 right-3 z-50 flex items-center justify-center w-9 h-9 rounded-lg bg-black/60 hover:bg-black/80 text-white transition-opacity opacity-0 group-hover:opacity-100 cursor-pointer backdrop-blur-sm border border-white/20"
-          >
-            <svg
-              className="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
+      <PinContext.Provider value={pinContextValue}>
+        <FocusLayoutContainer>
+          <CarouselLayout tracks={tracks}>
+            <CustomParticipantTile />
+          </CarouselLayout>
+          <div className="group relative flex-1 min-w-0 min-h-0">
+            <FocusLayout trackRef={screenTrack} />
+            <button
+              onClick={() => setIsFullscreen(true)}
+              title="Fullscreen"
+              className="absolute top-3 right-3 z-50 flex items-center justify-center w-9 h-9 rounded-lg bg-black/60 hover:bg-black/80 text-white transition-opacity opacity-0 group-hover:opacity-100 cursor-pointer backdrop-blur-sm border border-white/20"
             >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4 8V4m0 0h4M4 4l5 5M20 8V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5M20 16v4m0 0h-4m4 0l-5-5"
-              />
-            </svg>
-          </button>
-        </div>
-      </FocusLayoutContainer>
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 8V4m0 0h4M4 4l5 5M20 8V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5M20 16v4m0 0h-4m4 0l-5-5"
+                />
+              </svg>
+            </button>
+          </div>
+        </FocusLayoutContainer>
+      </PinContext.Provider>
+    );
+  }
+
+  // Pinned participant layout (no screen share)
+  if (pinnedIdentity && pinnedTrack) {
+    const otherTracks = tracks.filter(
+      (t) => t.participant?.identity !== pinnedIdentity,
+    );
+    return (
+      <PinContext.Provider value={pinContextValue}>
+        <FocusLayoutContainer>
+          <CarouselLayout tracks={otherTracks}>
+            <CustomParticipantTile />
+          </CarouselLayout>
+          <div className="group relative" style={{ height: "100%" }}>
+            <TrackRefContext.Provider value={pinnedTrack}>
+              <CustomParticipantTile />
+            </TrackRefContext.Provider>
+            <button
+              onClick={() => setPinnedIdentity(null)}
+              title="Unpin"
+              className="absolute top-3 right-3 z-50 flex items-center justify-center gap-1.5 px-3 h-9 rounded-lg bg-black/60 hover:bg-black/80 text-white text-xs font-medium transition-opacity opacity-0 group-hover:opacity-100 cursor-pointer backdrop-blur-sm border border-white/20"
+            >
+              <Pin className="w-4 h-4 fill-current" />
+              Unpin
+            </button>
+          </div>
+        </FocusLayoutContainer>
+      </PinContext.Provider>
     );
   }
 
   return (
-    <GridLayout tracks={tracks}>
-      <CustomParticipantTile />
-    </GridLayout>
+    <PinContext.Provider value={pinContextValue}>
+      <GridLayout tracks={tracks}>
+        <CustomParticipantTile />
+      </GridLayout>
+    </PinContext.Provider>
   );
 };

--- a/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
+++ b/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
@@ -79,12 +79,21 @@ export const VideoLayout: React.FC<VideoLayoutProps> = ({
       : null;
 
     const unpinnedTracks = pinnedIdentity
-      ? tracks.filter((t) => t.participant?.identity !== pinnedIdentity)
-      : tracks;
+      ? tracks.filter(
+          (t) =>
+            t.participant?.identity !== pinnedIdentity &&
+            t.source !== Track.Source.ScreenShare,
+        )
+      : tracks.filter((t) => t.source !== Track.Source.ScreenShare);
 
     const orderedTracks = pinnedCarouselTrack
       ? [pinnedCarouselTrack, ...unpinnedTracks]
       : null;
+
+    // Non-pinned case: also filter screen share from carousel
+    const carouselTracks = tracks.filter(
+      (t) => t.source !== Track.Source.ScreenShare,
+    );
 
     return (
       <PinContext.Provider value={pinContextValue}>
@@ -101,7 +110,7 @@ export const VideoLayout: React.FC<VideoLayoutProps> = ({
               ))}
             </div>
           ) : (
-            <CarouselLayout tracks={tracks}>
+            <CarouselLayout tracks={carouselTracks}>
               <CustomParticipantTile />
             </CarouselLayout>
           )}

--- a/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
+++ b/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
@@ -8,7 +8,6 @@ import {
 } from "@livekit/components-react";
 import { Track } from "livekit-client";
 import type { TrackReferenceOrPlaceholder } from "@livekit/components-react";
-import { Pin } from "lucide-react";
 import { CustomParticipantTile } from "../CustomParticipantTile";
 import { PinContext } from "./PinContext";
 

--- a/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
+++ b/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
@@ -69,12 +69,43 @@ export const VideoLayout: React.FC<VideoLayoutProps> = ({
       );
     }
 
+    // CarouselLayout uses useVisualStableUpdate internally and ignores order.
+    // When pinned, render all tiles manually so the pinned one stays first.
+    const pinnedCarouselTrack = pinnedIdentity
+      ? (tracks.find(
+          (t) =>
+            t.participant?.identity === pinnedIdentity &&
+            t.source === Track.Source.Camera,
+        ) ?? tracks.find((t) => t.participant?.identity === pinnedIdentity))
+      : null;
+
+    const unpinnedTracks = pinnedIdentity
+      ? tracks.filter((t) => t.participant?.identity !== pinnedIdentity)
+      : tracks;
+
+    const orderedTracks = pinnedCarouselTrack
+      ? [pinnedCarouselTrack, ...unpinnedTracks]
+      : null;
+
     return (
       <PinContext.Provider value={pinContextValue}>
         <FocusLayoutContainer>
-          <CarouselLayout tracks={tracks}>
-            <CustomParticipantTile />
-          </CarouselLayout>
+          {orderedTracks ? (
+            <div className="lk-carousel lk-carousel-vertical">
+              {orderedTracks.map((t) => (
+                <TrackRefContext.Provider
+                  key={`${t.participant?.identity ?? "placeholder"}-${t.source}`}
+                  value={t}
+                >
+                  <CustomParticipantTile />
+                </TrackRefContext.Provider>
+              ))}
+            </div>
+          ) : (
+            <CarouselLayout tracks={tracks}>
+              <CustomParticipantTile />
+            </CarouselLayout>
+          )}
           <div className="group relative flex-1 min-w-0 min-h-0">
             <FocusLayout trackRef={screenTrack} />
             <button

--- a/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
+++ b/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   GridLayout,
   FocusLayout,
@@ -18,15 +18,67 @@ export const VideoLayout: React.FC<VideoLayoutProps> = ({
   tracks,
   hasScreenShare,
 }) => {
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
   if (hasScreenShare) {
+    const screenTrack = tracks.find(
+      (t) => t.source === Track.Source.ScreenShare,
+    );
+
+    if (isFullscreen) {
+      return (
+        <div className="group relative w-full h-full bg-black">
+          <FocusLayout trackRef={screenTrack} />
+          <button
+            onClick={() => setIsFullscreen(false)}
+            title="Exit fullscreen"
+            className="absolute top-3 right-3 z-50 flex items-center justify-center w-9 h-9 rounded-lg bg-black/60 hover:bg-black/80 text-white transition-opacity opacity-0 group-hover:opacity-100 cursor-pointer backdrop-blur-sm border border-white/20"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 9L4 4m0 0l5 0M4 4l0 5M15 9l5-5m0 0l-5 0m5 0l0 5M9 15l-5 5m0 0l5 0m-5 0l0-5M15 15l5 5m0 0l-5 0m5 0l0-5"
+              />
+            </svg>
+          </button>
+        </div>
+      );
+    }
+
     return (
       <FocusLayoutContainer>
         <CarouselLayout tracks={tracks}>
           <CustomParticipantTile />
         </CarouselLayout>
-        <FocusLayout
-          trackRef={tracks.find((t) => t.source === Track.Source.ScreenShare)}
-        />
+        <div className="group relative flex-1 min-w-0 min-h-0">
+          <FocusLayout trackRef={screenTrack} />
+          <button
+            onClick={() => setIsFullscreen(true)}
+            title="Fullscreen"
+            className="absolute top-3 right-3 z-50 flex items-center justify-center w-9 h-9 rounded-lg bg-black/60 hover:bg-black/80 text-white transition-opacity opacity-0 group-hover:opacity-100 cursor-pointer backdrop-blur-sm border border-white/20"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 8V4m0 0h4M4 4l5 5M20 8V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5M20 16v4m0 0h-4m4 0l-5-5"
+              />
+            </svg>
+          </button>
+        </div>
       </FocusLayoutContainer>
     );
   }

--- a/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
+++ b/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
@@ -23,6 +23,32 @@ export const VideoLayout: React.FC<VideoLayoutProps> = ({
 }) => {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [pinnedIdentity, setPinnedIdentity] = useState<string | null>(null);
+  const [isPiP, setIsPiP] = useState(false);
+  const screenShareContainerRef = React.useRef<HTMLDivElement | null>(null);
+
+  const togglePiP = async () => {
+    try {
+      if (document.pictureInPictureElement) {
+        await document.exitPictureInPicture();
+        setIsPiP(false);
+      } else {
+        const video = screenShareContainerRef.current?.querySelector("video");
+        if (video) {
+          await video.requestPictureInPicture();
+          setIsPiP(true);
+        }
+      }
+    } catch (e) {
+      console.warn("PiP not supported:", e);
+    }
+  };
+
+  // Track PiP exit via browser controls
+  React.useEffect(() => {
+    const onExit = () => setIsPiP(false);
+    document.addEventListener("leavepictureinpicture", onExit);
+    return () => document.removeEventListener("leavepictureinpicture", onExit);
+  }, []);
 
   const pinContextValue = { pinnedIdentity, setPinnedIdentity };
 
@@ -117,27 +143,69 @@ export const VideoLayout: React.FC<VideoLayoutProps> = ({
               <CustomParticipantTile />
             </CarouselLayout>
           )}
-          <div className="group relative flex-1 min-w-0 min-h-0">
+          <div
+            ref={screenShareContainerRef}
+            className="group relative flex-1 min-w-0 min-h-0"
+          >
             <FocusLayout trackRef={screenTrack} />
-            <button
-              onClick={() => setIsFullscreen(true)}
-              title="Fullscreen"
-              className="absolute top-3 right-3 z-50 flex items-center justify-center w-9 h-9 rounded-lg bg-black/60 hover:bg-black/80 text-white transition-opacity opacity-0 group-hover:opacity-100 cursor-pointer backdrop-blur-sm border border-white/20"
+            {/* Floating toolbar — slides down from top on hover */}
+            <div
+              className="absolute top-0 left-1/2 -translate-x-1/2 z-50
+                flex items-center gap-0.5 px-2 py-1
+                bg-black/50 backdrop-blur-md rounded-b-xl border border-t-0 border-white/10
+                opacity-0 -translate-y-full group-hover:opacity-100 group-hover:translate-y-0
+                transition-all duration-200 ease-out"
             >
-              <svg
-                className="w-5 h-5"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
+              {/* Fullscreen */}
+              <button
+                onClick={() => setIsFullscreen(true)}
+                title="Fullscreen"
+                className="flex items-center justify-center w-7 h-7 rounded-lg text-white/80 hover:text-white hover:bg-white/10 transition-colors cursor-pointer"
               >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M4 8V4m0 0h4M4 4l5 5M20 8V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5M20 16v4m0 0h-4m4 0l-5-5"
-                />
-              </svg>
-            </button>
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 8V4m0 0h4M4 4l5 5M20 8V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5M20 16v4m0 0h-4m4 0l-5-5"
+                  />
+                </svg>
+              </button>
+              {/* PiP */}
+              {document.pictureInPictureEnabled && (
+                <>
+                  <div className="w-px h-3.5 bg-white/20 mx-0.5" />
+                  <button
+                    onClick={togglePiP}
+                    title={isPiP ? "Exit Mini Player" : "Mini Player"}
+                    className={`flex items-center justify-center w-7 h-7 rounded-lg transition-colors cursor-pointer ${
+                      isPiP
+                        ? "text-blue-400 bg-blue-500/20"
+                        : "text-white/80 hover:text-white hover:bg-white/10"
+                    }`}
+                  >
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7"
+                      />
+                    </svg>
+                  </button>
+                </>
+              )}
+            </div>
           </div>
         </FocusLayoutContainer>
       </PinContext.Provider>

--- a/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
+++ b/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
@@ -5,6 +5,7 @@ import {
   FocusLayoutContainer,
   CarouselLayout,
   TrackRefContext,
+  ParticipantContext,
 } from "@livekit/components-react";
 import { Track } from "livekit-client";
 import type { TrackReferenceOrPlaceholder } from "@livekit/components-react";
@@ -101,12 +102,14 @@ export const VideoLayout: React.FC<VideoLayoutProps> = ({
           {orderedTracks ? (
             <div className="lk-carousel lk-carousel-vertical">
               {orderedTracks.map((t) => (
-                <TrackRefContext.Provider
+                <ParticipantContext.Provider
                   key={`${t.participant?.identity ?? "placeholder"}-${t.source}`}
-                  value={t}
+                  value={t.participant}
                 >
-                  <CustomParticipantTile />
-                </TrackRefContext.Provider>
+                  <TrackRefContext.Provider value={t}>
+                    <CustomParticipantTile />
+                  </TrackRefContext.Provider>
+                </ParticipantContext.Provider>
               ))}
             </div>
           ) : (
@@ -141,23 +144,58 @@ export const VideoLayout: React.FC<VideoLayoutProps> = ({
     );
   }
 
-  // Pinned participant layout (no screen share)
+  // Pinned participant layout (no screen share) — custom flex layout
   if (pinnedIdentity && pinnedTrack) {
     const otherTracks = tracks.filter(
       (t) => t.participant?.identity !== pinnedIdentity,
     );
     return (
       <PinContext.Provider value={pinContextValue}>
-        <FocusLayoutContainer>
-          <CarouselLayout tracks={otherTracks}>
-            <CustomParticipantTile />
-          </CarouselLayout>
-          <div className="relative" style={{ height: "100%" }}>
-            <TrackRefContext.Provider value={pinnedTrack}>
-              <CustomParticipantTile />
-            </TrackRefContext.Provider>
+        <div
+          style={{
+            display: "flex",
+            width: "100%",
+            height: "100%",
+            gap: "8px",
+            padding: "8px",
+            boxSizing: "border-box",
+          }}
+        >
+          {/* Sidebar: other participants */}
+          {otherTracks.length > 0 && (
+            <div
+              style={{
+                width: "170px",
+                minWidth: "170px",
+                display: "flex",
+                flexDirection: "column",
+                overflowY: "auto",
+                gap: "8px",
+              }}
+            >
+              {otherTracks.map((t) => (
+                <div
+                  key={`${t.participant?.identity ?? "placeholder"}-${t.source}`}
+                  style={{ width: "150px", height: "150px", flexShrink: 0 }}
+                >
+                  <ParticipantContext.Provider value={t.participant}>
+                    <TrackRefContext.Provider value={t}>
+                      <CustomParticipantTile />
+                    </TrackRefContext.Provider>
+                  </ParticipantContext.Provider>
+                </div>
+              ))}
+            </div>
+          )}
+          {/* Main: pinned participant */}
+          <div style={{ flex: 1, minWidth: 0, position: "relative" }}>
+            <ParticipantContext.Provider value={pinnedTrack.participant}>
+              <TrackRefContext.Provider value={pinnedTrack}>
+                <CustomParticipantTile />
+              </TrackRefContext.Provider>
+            </ParticipantContext.Provider>
           </div>
-        </FocusLayoutContainer>
+        </div>
       </PinContext.Provider>
     );
   }

--- a/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
+++ b/frontend/src/components/meeting/LiveKitMeetingRoom/VideoLayout.tsx
@@ -113,18 +113,10 @@ export const VideoLayout: React.FC<VideoLayoutProps> = ({
           <CarouselLayout tracks={otherTracks}>
             <CustomParticipantTile />
           </CarouselLayout>
-          <div className="group relative" style={{ height: "100%" }}>
+          <div className="relative" style={{ height: "100%" }}>
             <TrackRefContext.Provider value={pinnedTrack}>
               <CustomParticipantTile />
             </TrackRefContext.Provider>
-            <button
-              onClick={() => setPinnedIdentity(null)}
-              title="Unpin"
-              className="absolute top-3 right-3 z-50 flex items-center justify-center gap-1.5 px-3 h-9 rounded-lg bg-black/60 hover:bg-black/80 text-white text-xs font-medium transition-opacity opacity-0 group-hover:opacity-100 cursor-pointer backdrop-blur-sm border border-white/20"
-            >
-              <Pin className="w-4 h-4 fill-current" />
-              Unpin
-            </button>
           </div>
         </FocusLayoutContainer>
       </PinContext.Provider>

--- a/frontend/src/hooks/useLobbyDevices/useAudioDeviceSwitching.ts
+++ b/frontend/src/hooks/useLobbyDevices/useAudioDeviceSwitching.ts
@@ -38,6 +38,11 @@ export function useAudioDeviceSwitching(props: UseAudioSwitchingProps) {
     const updateAudioStream = async () => {
       if (!selectedMic || !micEnabled || !permissionsGranted) return;
 
+      // If the current stream is already using the selected mic, skip restart
+      const currentAudioTrack = stream?.getAudioTracks()[0];
+      const currentMicId = currentAudioTrack?.getSettings()?.deviceId;
+      if (currentMicId === selectedMic) return;
+
       try {
         const constraints: MediaStreamConstraints = {
           video:

--- a/frontend/src/hooks/useLobbyDevices/useVideoDeviceSwitching.ts
+++ b/frontend/src/hooks/useLobbyDevices/useVideoDeviceSwitching.ts
@@ -38,6 +38,11 @@ export function useVideoDeviceSwitching(props: UseVideoSwitchingProps) {
     const updateVideoStream = async () => {
       if (!selectedCamera || !cameraEnabled || !permissionsGranted) return;
 
+      // If the current stream is already using the selected camera, skip restart
+      const currentVideoTrack = stream?.getVideoTracks()[0];
+      const currentDeviceId = currentVideoTrack?.getSettings()?.deviceId;
+      if (currentDeviceId === selectedCamera) return;
+
       try {
         const constraints: MediaStreamConstraints = {
           video: {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -687,6 +687,8 @@
   .lk-focus-layout {
     display: grid !important;
     grid-template-columns: 170px 1fr !important;
+    grid-template-rows: 1fr !important;
+    height: 100% !important;
     @apply gap-2;
   }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -663,7 +663,8 @@
   }
 
   /* Make all carousel items (participants) the same size when screen sharing */
-  .lk-focus-layout .lk-carousel > * {
+  .lk-focus-layout .lk-carousel > *,
+  .lk-focus-layout .lk-carousel-vertical > * {
     @apply w-37.5 h-37.5 min-w-37.5 min-h-37.5 max-w-37.5 max-h-37.5 shrink-0;
     aspect-ratio: auto !important;
   }
@@ -671,6 +672,11 @@
   /* Ensure carousel scrolls vertically and shows all participants equally */
   .lk-focus-layout .lk-carousel {
     @apply flex-col overflow-y-auto overflow-x-hidden gap-2 p-2 max-h-full;
+  }
+
+  /* Manual ordered carousel (used when a participant is pinned) */
+  .lk-focus-layout .lk-carousel-vertical {
+    @apply flex flex-col overflow-y-auto overflow-x-hidden gap-2 p-2 max-h-full;
   }
 
   /* Keep the focused track (screen share) large */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -678,6 +678,11 @@
     @apply flex-1 w-full h-full;
   }
 
+  /* Hide LiveKit's built-in expand button — we use our own custom fullscreen button */
+  .lk-focus-toggle-button {
+    display: none !important;
+  }
+
   /* Adjust focus layout container to give more space to screen share */
   .lk-focus-layout {
     display: grid !important;

--- a/frontend/src/pages/MeetingLobby/VideoPreview.tsx
+++ b/frontend/src/pages/MeetingLobby/VideoPreview.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import MediaControls from "../../components/meeting/MediaControls";
 import type { VideoPreviewProps } from "./types";
 
@@ -10,6 +10,14 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
   onToggleMic,
   onToggleCamera,
 }) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (videoRef.current) {
+      videoRef.current.srcObject = stream ?? null;
+    }
+  }, [stream]);
+
   return (
     <div
       className="relative aspect-video bg-black"
@@ -18,9 +26,7 @@ export const VideoPreview: React.FC<VideoPreviewProps> = ({
     >
       {cameraEnabled && stream ? (
         <video
-          ref={(video) => {
-            if (video) video.srcObject = stream;
-          }}
+          ref={videoRef}
           autoPlay
           playsInline
           muted


### PR DESCRIPTION
This pull request introduces participant pinning and improves video layout handling in the meeting UI, adds custom fullscreen and PiP controls for screen share, and optimizes device switching logic. The changes enhance user experience by allowing participants to be pinned, improving screen share controls, and reducing unnecessary device restarts.

**Participant Pinning & Layout Improvements**
* Added a `PinContext` and pin button to allow users to pin/unpin participants, updating `CustomParticipantTile` and `VideoLayout` to support pinning and custom layouts for pinned participants. [[1]](diffhunk://#diff-db152d423422fa8d0d0f3ceb8e4340b9731aac1659c3e06370dcab950016faf0R1-R13) [[2]](diffhunk://#diff-40268f2632f246220f0dc33878632273bced56ff38c212d443178a47c762a2a5R8-R38) [[3]](diffhunk://#diff-40268f2632f246220f0dc33878632273bced56ff38c212d443178a47c762a2a5R53-R66) [[4]](diffhunk://#diff-2090f06398f4964dcbbe3d9737344e0c0ea4f9c91ec757fdf7ad59020973b754L1-R13) [[5]](diffhunk://#diff-2090f06398f4964dcbbe3d9737344e0c0ea4f9c91ec757fdf7ad59020973b754R24-R276)
* Updated CSS to support manual vertical carousel layouts and sidebar for pinned participants, and hide LiveKit's built-in expand button in favor of a custom fullscreen button. [[1]](diffhunk://#diff-b6889d573bf684293ea3c3e654c123bd3502dd1f8155470375a1e5a906f0c236L666-R667) [[2]](diffhunk://#diff-b6889d573bf684293ea3c3e654c123bd3502dd1f8155470375a1e5a906f0c236R677-R697)

**Screen Share Controls**
* Added custom fullscreen and Picture-in-Picture (PiP) controls for screen share, including toolbar UI and event handling for PiP state.

**Device Switching Optimization**
* Improved audio and video device switching logic to avoid unnecessary restarts when the selected device is already in use. [[1]](diffhunk://#diff-fff545df636f84620c6d8bc91ed3742ff97d791f45c486061e684ffcb4041258R41-R45) [[2]](diffhunk://#diff-480a881d625e1882cc1b520d0491095d28b3757c70978421c86f34bed4c75c9dR41-R45)

**Miscellaneous**
* Refactored `useParticipantData` to use `useEnsureTrackRef` for improved participant tracking.
* Updated video preview logic in the meeting lobby to use a persistent `videoRef` for better React compatibility. [[1]](diffhunk://#diff-e9b11f5e07e86c83f65f263e3d0cc15ecc74cee44c5e06df0a03f4aed591209eL1-R1) [[2]](diffhunk://#diff-e9b11f5e07e86c83f65f263e3d0cc15ecc74cee44c5e06df0a03f4aed591209eR13-R20) [[3]](diffhunk://#diff-e9b11f5e07e86c83f65f263e3d0cc15ecc74cee44c5e06df0a03f4aed591209eL21-R29)